### PR TITLE
Change .travis.yml to java 8 with simple build and mock test step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 install:
 - ./gradlew clean jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ jdk: openjdk8
 # - ./gradlew clean jar
 
 script:
-- echo `testing coming soon´
+- echo testing coming soon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
 jdk: openjdk8
 
-install:
-- ./gradlew clean jar
+# I probably don't need this because Travis is doing a validation automatically:
+# https://docs.travis-ci.com/user/languages/java/#gradle-dependency-management
+# install:
+# - ./gradlew clean jar
 
 script:
 - echo `testing coming soon´

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-language: python
-install: "pip install -r requirements.txt"
+language: java
+jdk: oraclejdk8
+
+install:
+- ./gradlew clean jar
 
 script:
-  # Run ANSIBLE checks
-  # - ANSIBLE0008: Disabled for use of sudo warnings - to address
-  # - ANSIBLE0011: Disabled for all tasks which should be named
-  # - ANSIBLE0012: Disabled (should not change if nothings needs doing) - to address
-  # - ANSIBLE0013: Disabled - few uses of shell commands - to address
-  - find vagrant/provision -name "*.yml" -exec ansible-lint -x ANSIBLE008,ANSIBLE0011,ANSIBLE0012,ANSIBLE0013  {} +
+- echo `testing coming soon´

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:1.1.8.RELEASE"
-        classpath "de.gesellix:gradle-debian-plugin:14"
+        classpath "de.gesellix:gradle-debian-plugin:2022-04-24T14-15-00"
         classpath "com.moowork.gradle:gradle-grunt-plugin:0.6"
         classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:1.0.2"
         classpath 'se.transmode.gradle:gradle-docker:1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         mavenCentral()
         maven {
             url "http://dl.bintray.com/gesellix/gradle-plugins"
+            url "https://plugins.gradle.org/m2/"
         }
         jcenter()
     }


### PR DESCRIPTION
Part one: use java 8, build during install (validation), placeholder in script phase (test)